### PR TITLE
Refactor storage account creation to include table resources

### DIFF
--- a/infra/core/storage/storage-account.bicep
+++ b/infra/core/storage/storage-account.bicep
@@ -93,6 +93,10 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   resource tableServices 'tableServices' = if (!empty(tables)) {
     name: 'default'
     properties: {}
+    resource table 'tables' = [for table in tables: {
+      name: table.name
+      properties: {}
+    }]
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -144,7 +144,7 @@ module functionAppStorageBlobRoleAssignment 'core/security/role.bicep' = {
   scope: resourceGroup
   params: {
     principalId: functionApp.outputs.SERVICE_API_IDENTITY_PRINCIPAL_ID
-    roleDefinitionId: '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1' // Storage Blob Data Contributor
+    roleDefinitionId: '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1' // Storage Blob Data Reader
   }
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve the infrastructure configuration for storage and role assignments. The most important changes include adding support for a new storage table, updating parameters and variables, and organizing role assignments into separate modules.

### Storage Configuration Enhancements:

* Added a new table resource to the `tableServices` in `infra/core/storage/storage-account.bicep`.
* Introduced a new parameter `fhirStorageTableName` in `infra/main.bicep` to specify the name of the storage table.
* Added a new variable `tables` in `infra/main.bicep` to store the table configuration.
* Updated the `storageAccount` module in `infra/main.bicep` to include the `tables` variable.

### Role Assignment Organization:

* Refactored role assignments in `infra/main.bicep` by splitting them into separate modules for better organization and clarity.