### PR TITLE
Refactor connection strings in Java files to use "StorageConnStr" ins…

### DIFF
--- a/src/main/java/com/hephaestus/ImportProcessingQueueTrigger.java
+++ b/src/main/java/com/hephaestus/ImportProcessingQueueTrigger.java
@@ -25,7 +25,7 @@ public class ImportProcessingQueueTrigger {
      */
     @FunctionName("ImportProcessingQueueTrigger")
     public void run(
-        @QueueTrigger(name = "message", queueName = "import-processing", connection = "AzureWebJobsStorage") String message,
+        @QueueTrigger(name = "message", queueName = "import-processing", connection = "StorageConnStr") String message,
         final ExecutionContext context
     ) {
         context.getLogger().info("Java Queue trigger function processed a message: " + message);
@@ -47,7 +47,7 @@ public class ImportProcessingQueueTrigger {
             context.getLogger().info("Initializing TableServiceClient...");
             // Initialize TableServiceClient
             TableServiceClient tableServiceClient = new TableServiceClientBuilder()
-                .connectionString(System.getenv("AzureWebJobsStorage"))
+                .connectionString(System.getenv("StorageConnStr"))
                 .buildClient();
 
             context.getLogger().info("Getting a reference to the table...");

--- a/src/main/java/com/hephaestus/PreLoadBatchQueueTableHttp.java
+++ b/src/main/java/com/hephaestus/PreLoadBatchQueueTableHttp.java
@@ -33,7 +33,7 @@ public class PreLoadBatchQueueTableHttp {
 
         // Initialize TableServiceClient
         TableServiceClient tableServiceClient = new TableServiceClientBuilder()
-            .connectionString(System.getenv("AzureWebJobsStorage"))
+            .connectionString(System.getenv("StorageConnStr"))
             .buildClient();
 
         // Get a reference to the table

--- a/src/main/java/com/hephaestus/TimerStatusCheck.java
+++ b/src/main/java/com/hephaestus/TimerStatusCheck.java
@@ -52,7 +52,7 @@ public class TimerStatusCheck {
 
         // Initialize TableServiceClient
         TableServiceClient tableServiceClient = new TableServiceClientBuilder()
-            .connectionString(System.getenv("AzureWebJobsStorage"))
+            .connectionString(System.getenv("StorageConnStr"))
             .buildClient();
 
         // Get a reference to the table
@@ -60,7 +60,7 @@ public class TimerStatusCheck {
 
         // Initialize QueueClient
         QueueClient queueClient = new QueueClientBuilder()
-            .connectionString(System.getenv("AzureWebJobsStorage"))
+            .connectionString(System.getenv("StorageConnStr"))
             .queueName("import-processing")
             .buildClient();
 


### PR DESCRIPTION
This pull request updates the connection string used for Azure services across multiple files to ensure consistency and improve security. The changes mainly involve replacing the hardcoded connection string name `AzureWebJobsStorage` with `StorageConnStr`.

### Connection String Updates:

* [`src/main/java/com/hephaestus/ImportProcessingQueueTrigger.java`](diffhunk://#diff-ed20e9a2e23a669b47d0611971135d63e9b7ff4bc5ab54a99c0c2fa72307f15eL28-R28): Updated the connection string in both the `@QueueTrigger` annotation and the `TableServiceClient` initialization. [[1]](diffhunk://#diff-ed20e9a2e23a669b47d0611971135d63e9b7ff4bc5ab54a99c0c2fa72307f15eL28-R28) [[2]](diffhunk://#diff-ed20e9a2e23a669b47d0611971135d63e9b7ff4bc5ab54a99c0c2fa72307f15eL50-R50)
* [`src/main/java/com/hephaestus/PreLoadBatchQueueTableHttp.java`](diffhunk://#diff-afa08508fc92cbdd80ee18ac89a550dab3386bf4d650639035f4c459ed318bfbL36-R36): Changed the connection string for the `TableServiceClient` initialization.
* [`src/main/java/com/hephaestus/TimerStatusCheck.java`](diffhunk://#diff-49342134f8e5c1c22f2eb211e556279b9ea035727784c5e1b45468dc472dbfccL55-R63): Updated the connection string for both `TableServiceClient` and `QueueClient` initializations.…tead of "AzureWebJobsStorage"